### PR TITLE
[telepathy-mission-control] Prevent assert for offline accounts with power saving

### DIFF
--- a/rpm/0001-Prevent-assert-for-offline-accounts-with-power-savin.patch
+++ b/rpm/0001-Prevent-assert-for-offline-accounts-with-power-savin.patch
@@ -1,0 +1,30 @@
+From 1ff03849f9c02ba96b5dc7cedba8644cc1b06046 Mon Sep 17 00:00:00 2001
+From: John Brooks <john.brooks@jollamobile.com>
+Date: Thu, 12 Dec 2013 15:46:27 -0700
+Subject: [PATCH] Prevent assert for offline accounts with power saving
+
+---
+ src/mcd-connection.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/mcd-connection.c b/src/mcd-connection.c
+index 93b81d5..df35b4b 100644
+--- a/src/mcd-connection.c
++++ b/src/mcd-connection.c
+@@ -1678,10 +1678,10 @@ on_inactivity_changed (McdSlacker *slacker,
+     McdConnection *self)
+ {
+   McdConnectionPrivate *priv = self->priv;
+-  DEBUG ("%sactive, %s have power saving iface.", inactive ? "in" : "",
+-      priv->has_power_saving_if ? "has" : "doesn't");
++  DEBUG ("%sactive, connection %s have power saving iface.", inactive ? "in" : "",
++      priv->has_power_saving_if ? "does" : "doesn't");
+ 
+-  if (priv->has_power_saving_if)
++  if (priv->tp_conn != NULL && priv->has_power_saving_if)
+     tp_cli_connection_interface_power_saving_call_set_power_saving (priv->tp_conn, -1,
+         inactive, NULL, NULL, NULL, NULL);
+ }
+-- 
+1.8.3.1
+

--- a/rpm/telepathy-mission-control.spec
+++ b/rpm/telepathy-mission-control.spec
@@ -22,6 +22,7 @@ Patch1:     nemo-tests-dir-fix.patch
 Patch2:     nemo-fix-system-dbus-for-tests.patch
 Patch3:     disable-gtk-doc.patch
 Patch4:     0001-McdSlacker-Revert-use-of-org.gnome.SessionManager-in.patch
+Patch5:     0001-Prevent-assert-for-offline-accounts-with-power-savin.patch
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(dbus-1) >= 0.95
@@ -82,6 +83,8 @@ files for developing applications that use %{name}.
 %patch3 -p1
 # 0001-McdSlacker-Revert-use-of-org.gnome.SessionManager-in.patch
 %patch4 -p1
+# 0001-Prevent-assert-for-offline-accounts-with-power-savin.patch
+%patch5 -p1
 # >> setup
 %__cp $RPM_SOURCE_DIR/mktests.sh tests/twisted/
 %__chmod 0755 tests/twisted/mktests.sh

--- a/rpm/telepathy-mission-control.yaml
+++ b/rpm/telepathy-mission-control.yaml
@@ -21,6 +21,7 @@ Patches:
     - nemo-fix-system-dbus-for-tests.patch
     - disable-gtk-doc.patch
     - 0001-McdSlacker-Revert-use-of-org.gnome.SessionManager-in.patch
+    - 0001-Prevent-assert-for-offline-accounts-with-power-savin.patch
 
 PkgBR:
     - libxslt


### PR DESCRIPTION
This has no functional impact, but asserts are loud and dirty. Patch will be submitted upstream.
