### PR TITLE
Fix a few memory leaks

### DIFF
--- a/telepathy-mission-control/src/mcd-account.c
+++ b/telepathy-mission-control/src/mcd-account.c
@@ -438,10 +438,15 @@ mcd_account_get_parameter_of_known_type (McdAccount *account,
         {
             memcpy (parameter, &tmp, sizeof (tmp));
         }
+        else
+        {
+            g_value_unset (&tmp);
+        }
 
         return TRUE;
     }
 
+    g_value_unset (&tmp);
     return FALSE;
 }
 
@@ -3260,6 +3265,7 @@ finally:
     g_free (new_dir);
     g_free (contents);
     g_free (old_file);
+    g_free (old_dir);
 }
 
 static gboolean

--- a/telepathy-mission-control/src/mcd-dispatch-operation.c
+++ b/telepathy-mission-control/src/mcd-dispatch-operation.c
@@ -521,10 +521,7 @@ _mcd_dispatch_operation_check_client_locks (McdDispatchOperation *self)
     /* if we've been claimed, respond, then do not call HandleChannels */
     if (approval != NULL && approval->type == APPROVAL_TYPE_CLAIM)
     {
-        /* this needs to be copied because we don't use it til after we've
-         * freed approval->context */
-        gchar *caller = g_strdup (dbus_g_method_get_sender (
-            approval->context));
+        gchar *caller = dbus_g_method_get_sender (approval->context);
 
         /* remove this approval from the list, so it won't be treated as a
          * failure */
@@ -832,8 +829,13 @@ _mcd_dispatch_operation_finish (McdDispatchOperation *operation,
             case APPROVAL_TYPE_CLAIM:
                 /* someone else got it - either another Claim() or a handler */
                 g_assert (approval->context != NULL);
+                /*
+                  The statement below leaks memory because the value returned
+                  by dbus_g_method_get_sender() needs to be deallocated:
+
                 DEBUG ("denying Claim call from %s",
                        dbus_g_method_get_sender (approval->context));
+                */
                 dbus_g_method_return_error (approval->context, priv->result);
                 approval->context = NULL;
                 break;


### PR DESCRIPTION
```
==19990== 20 bytes in 2 blocks are definitely lost in loss record 1,441 of 4,225
==19990==    at 0x483F380: malloc (vg_replace_malloc.c:296)
==19990==    by 0x4C14083: g_malloc (gmem.c:104)
==19990==    by 0x4C076A3: g_key_file_parse_value_as_string (gkeyfile.c:4045)
==19990==    by 0x4C076A3: g_key_file_get_string (gkeyfile.c:1822)
==19990==    by 0x37CD5: mcd_keyfile_get_value (mcd-storage.c:1078)
==19990==    by 0x3816D: mcd_keyfile_unescape_value (mcd-storage.c:1044)
==19990==    by 0x293C3: mcd_account_get_parameter_of_known_type (mcd-account.c:435)
==19990==    by 0x29421: mcd_account_get_parameter (mcd-account.c:418)
==19990==    by 0x29495: mcd_account_check_parameters (mcd-account.c:2605)
==19990==    by 0x2DC57: async_altered_manager_cb (mcd-account-manager.c:174)
==19990==    by 0x4B89A59: g_closure_invoke (gclosure.c:777)
==19990==    by 0x4B98E19: signal_emit_unlocked_R (gsignal.c:3586)
==19990==    by 0x4B9F8AB: g_signal_emit_valist (gsignal.c:3330)
==19990==    by 0x4BA0005: g_signal_emit_by_name (gsignal.c:3426)
==19990==    by 0x52EB493: _service_changed_cb (mcp-account-manager-uoa.c:253)
==19990==    by 0x4B89C09: _g_closure_invoke_va (gclosure.c:840)
==19990==    by 0x4B9F235: g_signal_emit_valist (gsignal.c:3238)
==19990==    by 0x4B9FCA7: g_signal_emit (gsignal.c:3386)
==19990==    by 0x5303901: update_settings (ag-account.c:687)
==19990==    by 0x5303901: _ag_account_done_changes (ag-account.c:719)
==19990==    by 0x5307A39: exec_transaction (ag-manager.c:1016)
==19990==    by 0x53081E7: _ag_manager_exec_transaction (ag-manager.c:2380)
==19990==    by 0x530837B: ag_manager_store_local_async (ag-manager.c:2455)
==19990==    by 0x530837B: _ag_manager_store_async (ag-manager.c:2506)
==19990==    by 0x52EBDA3: account_manager_uoa_commit (mcp-account-manager-uoa.c:842)
==19990==    by 0x3948B: mcd_storage_commit (mcd-storage.c:2004)
==19990==    by 0x29081: mcd_account_set_string_val (mcd-account.c:1048)
==19990==    by 0x29373: mcd_account_self_contact_notify_alias_cb (mcd-account.c:4290)
==19990==    by 0x2A7CD: mcd_account_self_contact_upgraded_cb (mcd-account.c:4826)
==19990==    by 0x4AB9735: g_simple_async_result_complete (gsimpleasyncresult.c:777)
==19990==    by 0x4AB9801: complete_in_idle_cb (gsimpleasyncresult.c:789)
==19990==    by 0x4C0EB85: g_main_dispatch (gmain.c:3066)
==19990==    by 0x4C0EB85: g_main_context_dispatch (gmain.c:3642)
==19990==    by 0x4C0EE11: g_main_context_iterate.isra.5 (gmain.c:3713)
```
```
==19990== 192 bytes in 2 blocks are definitely lost in loss record 3,893 of 4,225
==19990==    at 0x4841DDC: realloc (vg_replace_malloc.c:692)
==19990==    by 0x4C14103: g_realloc (gmem.c:169)
==19990==    by 0x4C2DD91: g_string_maybe_expand (gstring.c:107)
==19990==    by 0x4C2DD91: g_string_insert_len (gstring.c:480)
==19990==    by 0x4BFAF91: g_build_path_va.constprop.1 (gfileutils.c:1764)
==19990==    by 0x4BFC135: g_build_filename (gfileutils.c:2034)
==19990==    by 0x2C039: _mcd_account_get_old_avatar_filename (mcd-account.c:4727)
==19990==    by 0x2C039: mcd_account_migrate_avatar (mcd-account.c:3171)
==19990==    by 0x2C039: _mcd_account_constructed (mcd-account.c:3601)
==19990==    by 0x4B853DB: g_object_new_with_custom_constructor (gobject.c:1721)
==19990==    by 0x4B8D2B7: g_object_new_internal (gobject.c:1744)
==19990==    by 0x4B8FBB7: g_object_new_valist (gobject.c:2002)
==19990==    by 0x4B9020B: g_object_new (gobject.c:1559)
==19990==    by 0x28945: mcd_account_new (mcd-account.c:3737)
==19990==    by 0x2F4B5: _mcd_account_manager_setup (mcd-account-manager.c:1446)
==19990==    by 0x1D171: mcd_master_constructor (mcd-master.c:392)
==19990==    by 0x4B852B3: g_object_new_with_custom_constructor (gobject.c:1665)
==19990==    by 0x4B8D2B7: g_object_new_internal (gobject.c:1744)
==19990==    by 0x4B8FBB7: g_object_new_valist (gobject.c:2002)
==19990==    by 0x4B9020B: g_object_new (gobject.c:1559)
==19990==    by 0x1CC0B: mcd_service_new (mcd-service.c:180)
==19990==    by 0x1B58F: main (mc-server.c:176)
```
```
==19990== 36 bytes in 6 blocks are definitely lost in loss record 2,286 of 4,225
==19990==    at 0x483F380: malloc (vg_replace_malloc.c:296)
==19990==    by 0x4C14083: g_malloc (gmem.c:104)
==19990==    by 0x4C2BAA9: g_strdup (gstrfuncs.c:364)
==19990==    by 0x346DF: _mcd_dispatch_operation_check_client_locks (mcd-dispatch-operation.c:526)
==19990==    by 0x358C1: _mcd_dispatch_operation_dec_observers_pending (mcd-dispatch-operation.c:318)
==19990==    by 0x358C1: observe_channels_cb (mcd-dispatch-operation.c:1971)
==19990==    by 0x4903A9F: _tp_cli_client_observer_invoke_callback_observe_channels (tp-cli-client-body.h:475)
==19990==    by 0x495D8CB: tp_proxy_pending_call_idle_invoke (proxy-methods.c:155)
==19990==    by 0x4C0EB85: g_main_dispatch (gmain.c:3066)
==19990==    by 0x4C0EB85: g_main_context_dispatch (gmain.c:3642)
==19990==    by 0x4C0EE11: g_main_context_iterate.isra.5 (gmain.c:3713)
==19990==    by 0x4C0F1D3: g_main_loop_run (gmain.c:3907)
==19990==    by 0x1B64B: main (mc-server.c:194)
```